### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/src/routes/api/image.ts
+++ b/src/routes/api/image.ts
@@ -16,11 +16,19 @@ image.get('/', async (req: Request, res: Response): Promise<void> => {
   console.log(newName)
 
   // paths to input and output images
-  const path1 = `./src/images/${filename}.jpg`
-  const path2 = `./src/thumb/${newName}.jpg`
+  const rootImages = path.resolve('./src/images');
+  const rootThumb = path.resolve('./src/thumb');
+  const path1 = path.resolve(rootImages, `${filename}.jpg`);
+  const path2 = path.resolve(rootThumb, `${newName}.jpg`);
 
   // validate the data
-  if (width > 0 && height > 0 && fs.existsSync(path1) === true) {
+  if (
+    width > 0 &&
+    height > 0 &&
+    path1.startsWith(rootImages) &&
+    path2.startsWith(rootThumb) &&
+    fs.existsSync(path1)
+  ) {
     try {
       // send exist image
       if (fs.existsSync(path2)) {


### PR DESCRIPTION
Potential fix for [https://github.com/Haitham-sh/Image-Processing-API/security/code-scanning/5](https://github.com/Haitham-sh/Image-Processing-API/security/code-scanning/5)

To fix the issue, we need to validate the constructed file paths to ensure they are within the intended directories (`./src/images/` and `./src/thumb/`). This can be achieved by normalizing the paths using `path.resolve` and then verifying that the resolved paths start with the expected root directories. If the validation fails, the request should be rejected with an appropriate error message.

Steps to fix:
1. Use `path.resolve` to normalize the paths for `path1` and `path2`.
2. Check that the normalized paths start with the expected root directories (`./src/images/` for `path1` and `./src/thumb/` for `path2`).
3. Reject the request if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
