### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "dotenv": "^10.0.0",
     "express": "^4.21.0",
     "morgan": "^1.10.0",
-    "sharp": "^0.34.2"
+    "sharp": "^0.34.2",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/src/routes/api/image.ts
+++ b/src/routes/api/image.ts
@@ -2,8 +2,18 @@ import express, { Request, Response } from 'express'
 import fs from 'fs'
 import path from 'path'
 import resizing from '../../utilities/resize'
+import rateLimit from 'express-rate-limit'
 
 const image = express.Router()
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: 'Too many requests from this IP, please try again later.'
+});
+
+image.use(limiter);
 
 image.get('/', async (req: Request, res: Response): Promise<void> => {
   const width = parseInt(req.query.width as unknown as string, 10)


### PR DESCRIPTION
Potential fix for [https://github.com/Haitham-sh/Image-Processing-API/security/code-scanning/1](https://github.com/Haitham-sh/Image-Processing-API/security/code-scanning/1)

To address the issue, we will introduce rate limiting to the route handler using the `express-rate-limit` package. This middleware will limit the number of requests a client can make within a specified time window. Specifically, we will:
1. Install and import the `express-rate-limit` package.
2. Configure a rate limiter with appropriate settings (e.g., 100 requests per 15 minutes).
3. Apply the rate limiter to the `/` route of the `image` router.

This approach ensures that the server is protected from excessive requests while maintaining the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
